### PR TITLE
Update EZTV.pm

### DIFF
--- a/lib/CinePantufas/Source/EZTV.pm
+++ b/lib/CinePantufas/Source/EZTV.pm
@@ -30,7 +30,7 @@ sub import {
 sub retrieve_show_list {
   my $class = shift;
 
-  my $resp = HTTP::Tiny->new->get('http://eztv.it');
+  my $resp = HTTP::Tiny->new->get('https://eztv.it');
 
   die "Failed: $resp->{status} $resp->{reason}\n"
     unless $resp->{success};


### PR DESCRIPTION
https is needed to connect otherwise it responds with a Moved Permanently error which HTTP::Tiny is not following by itself.
